### PR TITLE
Updated some comment docs; fixed spelling of "Encrypted"

### DIFF
--- a/sdk/rms_sdk/Consent/Consent.h
+++ b/sdk/rms_sdk/Consent/Consent.h
@@ -17,9 +17,6 @@
 
 namespace rmscore { namespace consent {
 
-/// <summary>
-/// Consent for accessing end user license url
-/// </summary>
 class Consent : public modernapi::IConsent
 {
 public:
@@ -28,10 +25,10 @@ public:
         return this->result_;
     }
 
-//    virtual void ConsentResult(const modernapi::ConsentResult& value) override
-//    {
-//        this->result_ = value;
-//    }
+    virtual void ConsentResult(const modernapi::ConsentResult& value) override
+    {
+        this->result_ = value;
+    }
 
     virtual modernapi::ConsentType Type() const override
     {
@@ -64,4 +61,3 @@ protected:
 } // namespace consent
 } // namespace rmscore
 #endif // CONSENT
-

--- a/sdk/rms_sdk/ModernAPI/AuthenticationCallbackImpl.h
+++ b/sdk/rms_sdk/ModernAPI/AuthenticationCallbackImpl.h
@@ -22,9 +22,11 @@ class DLL_PUBLIC_RMS AuthenticationCallbackImpl : public IAuthenticationCallback
 public:
 
   /**
-   * @brief You, the app developer, will implementate this method for the authentication callback.
-   * @param callback Pointer to the authentication callback method.
-   * @param userId User ID of the authentication requestor.
+   * @brief This class wraps an IAuthenticationCallback implementation
+   *        to provide OAuth coordinates.
+   * @param callback Authentication callback implementation.
+   * @param userId User ID of the authentication requestor, to be passed to
+   *        the IAuthenticationCallback.
    */
   AuthenticationCallbackImpl(IAuthenticationCallback& callback,
                              const std::string      & userId)
@@ -33,15 +35,19 @@ public:
   {}
 
   /**
-  @brief Gets the state of the need for authentication challenge.
+  @brief False if OAuth coordinates (authority, resource, scope) are already
+         known, True if these should be retrieved from challenge header in
+         401 Unauthorized response from API.
   */
   virtual bool NeedsChallenge() const override {
     return true;
   }
 
   /**
-  @brief Gets a OAuth access token through the authentication challenge method.
-  * @param challenge Pointer to the authentication challenge method.
+  * @brief Prepares AuthenticationParameters from AuthenticationChallenge
+  *        response, and passes these parameters to IAuthenticationCallback.
+  * @param challenge Package of coordinates received from API 401 Unauthorized
+  *        response.
   */
   virtual std::string GetAccessToken(const AuthenticationChallenge& challenge)
   override

--- a/sdk/rms_sdk/ModernAPI/AuthenticationParameters.h
+++ b/sdk/rms_sdk/ModernAPI/AuthenticationParameters.h
@@ -52,9 +52,9 @@ public:
 
   /**
   * @brief Coordinates for OAuth authentication.
-  * @param authority Authority with which the request is being made.
-  * @param resource Resource being requested.
-  * @param scope Scope of the authentication request.
+  * @param authority Authorization server trusted by API.
+  * @param resource URL representing RMS resource.
+  * @param scope Scope required in authorization request.
   * @param userId User ID of the requestor.
   */
   AuthenticationParameters(const std::string& authority,

--- a/sdk/rms_sdk/ModernAPI/CacheControl.h
+++ b/sdk/rms_sdk/ModernAPI/CacheControl.h
@@ -17,26 +17,27 @@ namespace modernapi {
  */
 enum ResponseCacheFlags {
 	/*!
-	*@brief Response not cached.
+	*@brief Response should not be cached.
 	*/
     RESPONSE_CACHE_NOCACHE = 0x00,
 
 	/*!
-	*@brief Response to be cached in memory.
+	* @brief Response should be cached in memory. Cached response will
+  *        be lost when process exits.
 	*/
     RESPONSE_CACHE_INMEMORY= 0x01,
 
 	/*!
-	*@brief Response to be cached to disk.
+	*@brief Response should be cached to disk. Cached response will be available
+  *       when library is used again.
 	*/
     RESPONSE_CACHE_ONDISK  = 0x02,
 
 	/*!
-	*@brief Response to be encrypted.
+	*@brief Response should be encrypted when written to disk.
 	*/
-    RESPONSE_CACHE_CRYPTED = 0x04,
+    RESPONSE_CACHE_ENCRYPTED = 0x04,
 };
 } // namespace modernapi
 } // namespace rmscore
 #endif // _RMS_LIB_CACHECONTROL_H
-

--- a/sdk/rms_sdk/ModernAPI/ConsentCallbackImpl.h
+++ b/sdk/rms_sdk/ModernAPI/ConsentCallbackImpl.h
@@ -17,24 +17,24 @@
 namespace rmscore {
 namespace modernapi {
 /*
-* @brief Class providing the implementation of the user consent callback.
+* @brief Class wrapping IConsentCallback provided by library client.
 */
 class ConsentCallbackImpl : public IConsentCallbackImpl {
 public:
   /*
-   * @brief Implementation for user consent callback.
-   * @param callback Pointer to the consent callback method.
-   * @param userId UserId of consenting user.
+   * @brief Implementation of IConsentCallbackImpl.
+   * @param callback The IConsentCallback provided by the library client.
+   * @param userId ID of the user to be passed to the IConsentCallback.
    * @param isPublishing Flag for publishing state.
    */
   ConsentCallbackImpl(IConsentCallback & callback,
                       const std::string& userId,
                       bool               isPublishing);
   /*!
-  * @brief User consent.
+  * @brief Prepares Consent objects to pass to IConsentCallback.
   * @param email Email of the consenting user.
-  * @param domain Domain information.
-  * @param urls List of URLs that need to provide consent.
+  * @param domain Domain of the consenting user.
+  * @param urls List of URLs for which the user should provide consent.
   */
   virtual void Consents(const std::string             & email,
                         const std::string             & domain,

--- a/sdk/rms_sdk/ModernAPI/CustomProtectedStream.h
+++ b/sdk/rms_sdk/ModernAPI/CustomProtectedStream.h
@@ -19,59 +19,70 @@ namespace modernapi {
 /*!
  * @brief Used to access files that use a custom protection format.
  *
- *        Important - RMS applications that use CustomProtectedStream may be 
- *        incompatible with SharePoint, Exchange, and other RMS applications. 
- *        For most applications, it is recommended that you use ProtectedFileStream instead.
+ *        **Important** - RMS applications that use CustomProtectedStream may be
+ *        incompatible with SharePoint, Exchange, and other RMS applications.
+ *        For most applications, it is recommended that you use
+ *        ProtectedFileStream instead.
  */
 class DLL_PUBLIC_RMS CustomProtectedStream : public rmscrypto::api::IStream {
 public:
 
   /*!
-   * @brief Creates a CustomProtectedStream object based on the specified protection policy 
-   *        and a backing stream. 
+   * @brief Creates a CustomProtectedStream object based on the specified
+   *        protection policy and a backing stream.
    *
-   *        The CustomProtectedStream can be used for both encrypting and decrypting content. 
-   *        If the backing stream already contains encrypted content, you can use the stream 
-   *        reading functions to decrypt the content. You can also use stream writing functions 
-   *        to encrypt the content and write the encrypted content to the backing stream. 
+   *        The CustomProtectedStream can be used for both encrypting and
+   *        decrypting content.
+   *        If the backing stream already contains encrypted content,
+   *        you can use the stream Read* methods to decrypt and read it.
+   *        You can also use stream Write* methods to encrypt and write
+   *        content to the backing stream.
    *
-   *        Warning - To avoid data loss and/or corruption, FlushAsync must be called if you modify 
-   *        the created stream or before object disposal.
+   *        **Warning** - To avoid data loss and/or corruption, the Flush*
+   *        methods must be called if you modify the created stream before the
+   *        stream goes out of scope or is manually disposed.
    *
-   *        Remarks - You specify a range (contentStartPosition, contentSize) where the encrypted content 
-   *                  is located in the backing stream.
-   *                  If there is no existing content in the backing stream (for example, if this is a new file), 
-   *                    specify contentSize as zero. 
-   *                  If the existing content ends at the end of the stream, you can specify ulong.MaxValue for contentSize.
-   *                  The contentSize parameter is needed only for the cases when there is non-encrypted app-specific 
-   *                    content after the encrypted content. This is because the framework needs to know where the encrypted 
-   *                    content ends when performing decryption.
-   *                  The contentSize parameter is specified in terms of the encrypted content for example, it does include 
-   *                    the size of the CBC padding. 
-   *                  If the range defined by the parameters contentStartPosition and contentSize is not empty 
-   *                    (for example, contentSize != 0), it must address an entire segment of encrypted content; 
-   *                    that is, it must start from block 0 and must have a final block in the CBC case or should 
-   *                    be 16-byte aligned in the ECB case.
+   *        **Warning** - This method must be called on a UI thread. Calling it
+   *        on a worker thread may result in an unexpected behavior.
    *
-   *        Warning- To avoid data loss and/or corruption, FlushAsync must be called if you modify the created stream or before object disposal.
-   * 
-   *        Warning - This method must be called on a UI thread. Calling it on a worker thread may result in an unexpected behavior.
+   * @remarks You must specify a range (contentStartPosition, contentSize)
+   *          where the encrypted content is located in the backing stream.
+   *          If there is no existing content in the backing stream
+   *          (e.g. a new file), specify contentSize as 0.
+   *          If the existing content ends at the end of the stream, you can
+   *          specify ulong.MaxValue for contentSize.
+   *          The contentSize parameter is needed only for those cases
+   *          where there is non-encrypted app-specific content *after* the
+   *          encrypted content; in this case the method needs to know where the
+   *          encrypted content ends when performing decryption.
+   *          The contentSize parameter is specified in terms of the encrypted
+   *          content. For example, it should include the size of the CBC
+   *          padding.
+   *          If the range defined by the parameters contentStartPosition and
+   *          contentSize is not empty (i.e. contentSize != 0), it must address
+   *          an entire segment of encrypted content; that is, it must start
+   *          from block 0 and must have a final block (for CBC) or be 16-byte
+   *          aligned (for ECB).
    *
    * @param policy The user policy to apply to protect the content.
    * @param stream The backing stream.
-   * @param contentStartPosition The start position of the stream.
-   * @param contentSize The size of the encrypted content.
-   * @return A CustomProtectedStream object that can be used to write content to the file. 
+   * @param contentStartPosition The start position of encrypted content
+                                 within the stream.
+   * @param contentSize The size of the encrypted content within the stream.
+   * @return A CustomProtectedStream object that can be used to write content to
+             the encrypted portion of the backing stream.
    */
-  static std::shared_ptr<CustomProtectedStream>Create(
+  static std::shared_ptr<CustomProtectedStream> Create(
     std::shared_ptr<UserPolicy>  policy,
     rmscrypto::api::SharedStream stream,
     uint64_t                     contentStartPosition,
     uint64_t                     contentSize);
+
   /*!
-  * @brief Calculates the length of the encrypted content from the length of the clear content.
+  * @brief Calculates the length of the encrypted content from the length of the
+           plaintext content.
   * @param policy Pointer to userPolicy object.
-  * @param contentLenght Length of the clear content.
+  * @param contentLenght Length of the plaintext content.
   * @return The encrypted content length.
   */
   static uint64_t GetEncryptedContentLength(
@@ -79,12 +90,19 @@ public:
     uint64_t                   contentLength);
 
   /*!
-  * @brief Returns an asynchronous byte reader object.
-  * @param pbBuffer The buffer into which the asynchronous read operation places the bytes that are read. 
-  * @param cbBuffer 
-  * @param cbOffset
-  * @param launchType
-  * @return Count of bytes read.
+  * @brief Requests contents of the stream to be read asynchronously into
+           pbBuffer, and returns a std::shared_future to track status of the
+           asynchronous operation. Call .get() or .wait() on this shared_future
+           to synchronously await its completion.
+  * @param pbBuffer The buffer into which the (asynchronous) read operation
+                    should place read bytes.
+  * @param cbBuffer Count of bytes in this buffer.
+  * @param cbOffset Offset into the buffer where bytes should begin being
+                    written.
+  * @param launchType Can be std::launch::async and/or std::launch::deferred.
+                      If deferred, read will take place "lazily" - i.e. only
+                      when get() or wait() is called.
+  * @return (Future of) count of bytes read.
   */
   virtual std::shared_future<int64_t>ReadAsync(uint8_t    *pbBuffer,
                                                int64_t     cbBuffer,
@@ -93,12 +111,19 @@ public:
   override;
 
   /*!
-  * @brief Writes data asynchronously to the backing file.
-  * @param cpbBuffer Pointer to the buffer into which the asynchronous write operation writes. 
-  * @param cbBuffer
-  * @param cbOffset
-  * @param launchType
-  * @return Count of bytes written.
+  * @brief Requests that data from *cpbBuffer be written asynchronously to
+           stream, and returns a std::shared_future to track status of the
+           asynchronous operation. Call .get() or .wait() on this shared_future
+           to synchronously await its completion.
+  * @param cpbBuffer Pointer to the buffer from which the write operation will
+                     read contents to be written.
+  * @param cbBuffer  Count of bytes in cpbBuffer.
+  * @param cbOffset  Offset into cpbBuffer where operation will begin reading
+                     from for write.
+  * @param launchType Can be std::launch::async and/or std::launch::deferred.
+                      If deferred, write will take place "lazily" - i.e. only
+                      when get() or wait() is called.
+  * @return (Future of) count of bytes written.
   */
   virtual std::shared_future<int64_t>WriteAsync(const uint8_t *cpbBuffer,
                                                 int64_t        cbBuffer,
@@ -107,52 +132,56 @@ public:
   override;
 
   /*!
-  * @brief Flushes the data asynchronously to the backing file.
-  * @param launchType
-  * @return The stream flush operation. null is returned if an exception occurs. 
-  *         Upon completion, IAsyncOperation.GetResults returns True if the file 
-  *         has been successfully flushed; otherwise, false. 
+  * @brief Requests that pending data be flushed asynchronously to
+           stream, and returns a std::shared_future to track status of the
+           asynchronous operation. Call .get() or .wait() on this shared_future
+           to synchronously await its completion.
+  * @param launchType Can be std::launch::async and/or std::launch::deferred.
+                      If deferred, flush will take place "lazily" - i.e. only
+                      when get() or wait() is called.
+  * @return (Future of) the result of the flush operation. True if data was
+            successfully flushed; otherwise False.
   */
   virtual std::future<bool>            FlushAsync(std::launch launchType)
   override;
 
   /*!
-  * @brief Reads data from the backing file.
-  * @param pbBuffer The buffer into which the read operation places the bytes that are read. 
-  * @param cbBuffer The number of bytes to read that is less than or equal to the capacity of the buffer.
-  * @return Bytes read.
+  * @brief Reads data from the backing stream.
+  * @param pbBuffer The buffer into which the read operation puts the bytes that
+                    are read.
+  * @param cbBuffer The number of bytes available in the buffer.
+  * @return Number of bytes actually read.
   */
   virtual int64_t                      Read(uint8_t *pbBuffer,
                                             int64_t  cbBuffer) override;
 
   /*!
-  * @brief Writes data to the backing file.
-  * @param cpbBuffer The buffer into which the write operation writes. 
+  * @brief Writes data to the backing stream.
+  * @param cpbBuffer The buffer from which the write operation reads data
+                     to be written.
   * @param cbBuffer The size of the buffer.
-  * @return Bytes written.
+  * @return Number of bytes written.
   */
   virtual int64_t                      Write(const uint8_t *cpbBuffer,
                                              int64_t        cbBuffer) override;
 
   /*!
-  * @brief Flushes the data to the backing file.
-  * @return The stream flush operation. null is returned if an exception occurs. 
-  *         Upon completion, IAsyncOperation.GetResults returns True if the file 
-  *         has been successfully flushed; otherwise, false. 
+  * @brief Flushes the data to the backing stream.
+  * @return The result of the flush operation. True if data was
+            successfully flushed; otherwise False.
   */
   virtual bool                         Flush() override;
 
   /*!
-  * @brief Creates a new instance of CustomProtectedStream over the protected content.
-  * @return A CustomProtectedStream object that represents the new stream. The initial, 
-  *         internal position of the stream is 0 (zero). The internal position and lifetime 
-  *         of the new stream are independent from the position and lifetime of the cloned stream.
+  * @brief Creates a copy of the CustomProtectedStream.
+  * @return A CustomProtectedStream object that represents the new stream.
+           The initial seek position of the stream is 0. The seek position and lifetime of the new stream are independent of the position and lifetime of the original stream.
   */
   virtual rmscrypto::api::SharedStream Clone() override;
 
   /*!
-  * @brief Sets the current position to the specified number of bytes from the start of the file.
-  * @param u64Position The number of bytes from the start of the file at which to set the position. 
+  * @brief Sets the current position to the specified offset in the stream.
+  * @param u64Position The offset in the stream to move to.
   */
   virtual void                         Seek(uint64_t u64Position) override;
 
@@ -169,8 +198,8 @@ public:
   virtual bool                         CanWrite() const           override;
 
   /*!
-  * @brief Gets the current file position in bytes.
-  * @return The current file position in bytes.
+  * @brief Gets the current file seek offset.
+  * @return The current file seek offset.
   */
   virtual uint64_t                     Position()                 override;
 
@@ -181,12 +210,11 @@ public:
   virtual uint64_t                     Size()                     override;
 
   /*!
-  * @brief Sets the size of the protected data in bytes. 
+  * @brief Sets the size of the protected data in bytes.
   * @param u64Value Size of the protected data in bytes.
   */
   virtual void                         Size(uint64_t u64Value)    override;
 
-  //
   virtual ~CustomProtectedStream();
 
 protected:

--- a/sdk/rms_sdk/ModernAPI/HttpHelper.h
+++ b/sdk/rms_sdk/ModernAPI/HttpHelper.h
@@ -6,8 +6,8 @@
  * ======================================================================
 */
 
-#ifndef _RMS_LIB_HTTPHELPER_H
-#define _RMS_LIB_HTTPHELPER_H
+#ifndef _RMS_LIB_HTTPHELPER_H_
+#define _RMS_LIB_HTTPHELPER_H_
 
 #include <vector>
 #include <stdint.h>
@@ -17,26 +17,29 @@
 namespace rmscore {
 namespace modernapi {
 /*!
- * @brief Helper class provides methods for ...
+ * @brief Helper class to add additional trusted CA certificates for use
+          only with this library.
  */
 class DLL_PUBLIC_RMS HttpHelper {
 public:
 
  /*!
-  * @brief To use trusted CA put certificates - Base64
-  * @param certificate
-  * @return True or False
+  * @brief Adds trusted CA certificates for use only with this library.
+           Certificates should be serialized in Base64 format.
+  * @param certificate Serialized certificate.
+  * @return True if operation succeeded, otherwise false.
   */
   static bool addCACertificateBase64(const std::vector<uint8_t>& certificate);
 
   /*!
-  * @brief To use trusted CA put certificates - DER
-  * @param certificate
-  * @return True or False
+  * @brief Adds trusted CA certificates for use only with this library.
+           Certificates should be serialized in DER format.
+  * @param certificate Serialized certificate.
+  * @return True if operation succeeded, otherwise false.
   */
   static bool addCACertificateDer(const std::vector<uint8_t>& certificate);
 };
 } // namespace modernapi
 } // namespace rmscore
 
-#endif // _RMS_LIB_HTTPHELPER_H
+#endif // _RMS_LIB_HTTPHELPER_H_

--- a/sdk/rms_sdk/ModernAPI/IConsentCallback.h
+++ b/sdk/rms_sdk/ModernAPI/IConsentCallback.h
@@ -18,16 +18,19 @@ namespace modernapi {
 using ConsentList = std::vector<std::shared_ptr<IConsent> >;
 
 /*!
-* @brief Interface for displaying consents. This callback is provided by the app
-*        developer to know when and which consent notifications to display to user.
+* @brief Callback to be provided by library user to notify app user of actions to
+         be taken and request their consent.
 */
 class IConsentCallback {
 public:
 
 /*!
-* @brief You, the app developer, should implement this method and return consents.
-* @param consents List of Consents
-* @return Access token
+* @brief Library user should implement this method to notify app user of actions
+         to be taken and request their consent.
+* @param consents List of Consent objects containing details about actions to
+                  be taken.
+* @return Same list of consents; method should set Result for each Consent to
+          true or false.
 */
   virtual ConsentList Consents(ConsentList& consents) = 0;
 };

--- a/sdk/rms_sdk/ModernAPI/ProtectedFileStream.h
+++ b/sdk/rms_sdk/ModernAPI/ProtectedFileStream.h
@@ -184,7 +184,7 @@ public:
     ResponseCacheFlags           cacheMask
       = static_cast<ResponseCacheFlags>(RESPONSE_CACHE_INMEMORY |
                                         RESPONSE_CACHE_ONDISK |
-                                        RESPONSE_CACHE_CRYPTED));
+                                        RESPONSE_CACHE_ENCRYPTED));
 
   /*!
   @brief Wrap a new stream as a protected stream.

--- a/sdk/rms_sdk/RestClients/UsageRestrictionsClient.cpp
+++ b/sdk/rms_sdk/RestClients/UsageRestrictionsClient.cpp
@@ -38,8 +38,8 @@ GetUsageRestrictions(const UsageRestrictionsRequest        & request,
   std::shared_ptr<UsageRestrictionsResponse> response =
     make_shared<UsageRestrictionsResponse>();
 
-  bool cryptData = (cacheMask& modernapi::RESPONSE_CACHE_CRYPTED) ==
-                   modernapi::RESPONSE_CACHE_CRYPTED;
+  bool cryptData = (cacheMask& modernapi::RESPONSE_CACHE_ENCRYPTED) ==
+                   modernapi::RESPONSE_CACHE_ENCRYPTED;
   bool useCache = (cacheMask& modernapi::RESPONSE_CACHE_ONDISK)  ==
                   modernapi::RESPONSE_CACHE_ONDISK;
 

--- a/sdk/rmscrypto_sdk/UnitTests/EncryptedStreamTests.cpp
+++ b/sdk/rmscrypto_sdk/UnitTests/EncryptedStreamTests.cpp
@@ -7,12 +7,12 @@
  */
 
 #include <sstream>
-#include "CryptedStreamTests.h"
+#include "EncryptedStreamTests.h"
 #include "../CryptoAPI/CryptoAPI.h"
 #include "../CryptoAPI/RMSCryptoExceptions.h"
 
 using namespace std;
-void CryptedStreamTests::CryptedStreamToMemory_data() {
+void EncryptedStreamTests::EncryptedStreamToMemory_data() {
   QTest::addColumn<QString>("aesKey");
   QTest::addColumn<QString>("plainData");
   QTest::addColumn<QString>("iv");
@@ -25,7 +25,7 @@ void CryptedStreamTests::CryptedStreamToMemory_data() {
     static_cast<qint8>(rmscrypto::api::CIPHER_MODE_CBC4K);
 }
 
-void CryptedStreamTests::CryptedStreamToMemory() {
+void EncryptedStreamTests::EncryptedStreamToMemory() {
   shared_ptr<stringstream> backingBuffer = make_shared<stringstream>(
     ios::in | ios::out | ios::binary);
   vector<uint8_t> key(16);

--- a/sdk/rmscrypto_sdk/UnitTests/EncryptedStreamTests.h
+++ b/sdk/rmscrypto_sdk/UnitTests/EncryptedStreamTests.h
@@ -6,19 +6,19 @@
  * ======================================================================
 */
 
-#ifndef CRYPTEDSTREAMTESTS_H
-#define CRYPTEDSTREAMTESTS_H
+#ifndef ENCRYPTEDSTREAMTESTS_H
+#define ENCRYPTEDSTREAMTESTS_H
 #include <QTest>
 
 
-class CryptedStreamTests : public QObject
+class EncryptedStreamTests : public QObject
 {
     Q_OBJECT
 
 private Q_SLOTS:
 
-  void CryptedStreamToMemory_data();
-  void CryptedStreamToMemory();
+  void EncryptedStreamToMemory_data();
+  void EncryptedStreamToMemory();
 };
 
-#endif // CRYPTEDSTREAMTESTS_H
+#endif // ENCRYPTEDSTREAMTESTS_H

--- a/sdk/rmscrypto_sdk/UnitTests/UnitTests.pro
+++ b/sdk/rmscrypto_sdk/UnitTests/UnitTests.pro
@@ -33,12 +33,12 @@ SOURCES += \
     main.cpp \
     PlatformCryptoTest.cpp \
     KeyStorageTests.cpp \
-    CryptedStreamTests.cpp \
+    EncryptedStreamTests.cpp \
     CryptoAPITests.cpp
 
 HEADERS += \
     KeyStorageTests.h \
     PlatformCryptoTest.h \
-    CryptedStreamTests.h \
+    EncryptedStreamTests.h \
     TestHelpers.h \
     CryptoAPITests.h

--- a/sdk/rmscrypto_sdk/UnitTests/main.cpp
+++ b/sdk/rmscrypto_sdk/UnitTests/main.cpp
@@ -8,7 +8,7 @@
 
 #include<QApplication>
 #include "KeyStorageTests.h"
-#include "CryptedStreamTests.h"
+#include "EncryptedStreamTests.h"
 #include "CryptoAPITests.h"
 
 int main(int argc, char *argv[])
@@ -19,7 +19,7 @@ int main(int argc, char *argv[])
 
     res += QTest::qExec(new CryptoAPITests(), argc, argv);
     res += QTest::qExec(new KeyStorageTests(), argc, argv);
-    res += QTest::qExec(new CryptedStreamTests(), argc, argv);
+    res += QTest::qExec(new EncryptedStreamTests(), argc, argv);
 
     return res;
 }


### PR DESCRIPTION
Updated comment docs for about half of headers in rms_sdk/ModernAPI.
Cache policy was named "CRYPTED" - changed to "ENCRYPTED" everywhere.
